### PR TITLE
Made all levels not starting with sample_ get .gitignore'd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 ppl-utils
 ppl-utils.exe
 ppl-utils-*zip
+
+#Custom levels
+content/levels/*
+!content/levels/sample_*


### PR DESCRIPTION
This prevents anything from `content/levels` from being tracked *except* files and folders starting with `sample_`