### PR TITLE
Added filename filter

### DIFF
--- a/level_helpers.go
+++ b/level_helpers.go
@@ -99,7 +99,7 @@ func canRead(path string) bool {
 
 // GetLevelData returns a zip containing the level.
 // levelID is the path to the directory containing the level.
-func GetLevelData(levelID string) (bytes.Buffer, error) {
+func GetLevelData(levelID string, disableFilter bool) (bytes.Buffer, error) {
 	var buffer bytes.Buffer
 	if !canRead(levelID) {
 		return buffer, errors.New("Can't read path")
@@ -109,6 +109,9 @@ func GetLevelData(levelID string) (bytes.Buffer, error) {
 
 	filepath.Walk(levelID,
 		func(path string, info os.FileInfo, err error) error {
+			if !disableFilter && string(path[len(path)-3:]) != "lua" {
+				return nil
+			}
 			log.Print(path)
 			path = strings.ReplaceAll(path, string(os.PathSeparator), "/")
 			var header zip.FileHeader

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -50,7 +51,7 @@ func getLevel(w http.ResponseWriter, r *http.Request) {
 		log.Print(err.Error())
 		return
 	}
-	levelData, err := GetLevelData(strippedLevelID)
+	levelData, err := GetLevelData(strippedLevelID, len(os.Args) > 1 && os.Args[1] == "--disable-ext-filter")
 	if err != nil {
 		log.Print(err.Error())
 		return


### PR DESCRIPTION
ppl-utils was for whatever reason packing non-lua files (and also trying and failing to pack the folders themselves) into the level's zip. This fixes that and has an option to disable the fix by providing the argument --disable-ext-filter